### PR TITLE
Refactor: interpolate current palette to mini version with id

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -95,23 +95,24 @@ function savePalette() {
         savedPalettes.push(freshPalette)
         console.log(savedPalettes)
     }
-    makeNewPalette() 
+    makeNewPalette()
     displaySaved()
     append()
 }
 function append () {
-
-var testing = document.createElement('figure')
-testing.classList.add('mini-hex-container')
-testing.innerHTML = `<div class="mini-hex mini-hex1"></div>
-<div class="mini-hex mini-hex2"></div>
-<div class="mini-hex mini-hex3"></div>
-<div class="mini-hex mini-hex4"></div>
-<div class="mini-hex mini-hex5"></div>
-<img class="mini-hex" id="t-can" src="./assets/SVG/trash-can.svg" alt="t-can">`
-savedSection.appendChild(testing)
-displaySaved()
+  var testing = document.createElement('figure')
+  testing.classList.add('mini-hex-container')
+  testing.setAttribute('id',`${freshPalette.id}`)
+  testing.innerHTML = `<div class="mini-hex mini-hex1" style="background: ${freshPalette.colors[0].color};"></div>
+  <div class="mini-hex mini-hex2" style="background:${freshPalette.colors[1].color};"></div>
+  <div class="mini-hex mini-hex3" style="background:${freshPalette.colors[2].color};"></div>
+  <div class="mini-hex mini-hex4" style="background:${freshPalette.colors[3].color};"></div>
+  <div class="mini-hex mini-hex5" style="background:${freshPalette.colors[4].color};"></div>
+  <img class="mini-hex" id="t-can" src="./assets/SVG/trash-can.svg" alt="t-can">`
+  savedSection.appendChild(testing)
+  displaySaved()
 }
+
 
 function displaySaved() {
   savedSection.classList.remove('hidden')
@@ -128,7 +129,7 @@ function displaySaved() {
 
 
 function genColor(){
-    var hexId = ``;
+    var hexId = "";
     var combos = `abcdef0123456789`;
     for(var i = 0; i < 6; i++){
     hexId += combos.charAt(Math.floor(Math.random() * combos.length));


### PR DESCRIPTION
## Interpolate min-palette
**scripts.js**
- refactor lines 104 - 111
- interpolates current id and colors into mini version
